### PR TITLE
fix: update $ replace with global regexp

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,8 @@ export function join(path1: string, path2: string): string {
 }
 
 let encode = encodeURIComponent;
-let encodeKey = k => encode(k).replace('%24', '$');
+const dollarSignRegex: RegExp = new RegExp('%24', 'g');
+let encodeKey = k => encode(k).replace(dollarSignRegex, '$');
 /**
 * Recursively builds part of query string for parameter.
 *


### PR DESCRIPTION
Previous code was throwing `This replaces only the first occurrence of "%24".` error in CodeQL.